### PR TITLE
add migration for increasing title from 32 to 64 chars

### DIFF
--- a/controllers/ImportController.php
+++ b/controllers/ImportController.php
@@ -261,7 +261,7 @@ window.parent.CKEDITOR.tools.callFunction(".$_GET['CKEditorFuncNum'].", '".$mode
 		$model = new P3Media;
 		$model->detachBehavior('Upload');
 
-		$model->title = substr($fileName, 0, 25) . '-' . substr(uniqid(), -6); #P3StringHelper::cleanName($fileName, 32); // TODO: Add uniqid for title, so there's no unique conflict
+		$model->title = substr($fileName, 0, 57) . '-' . substr(uniqid(), -6); #P3StringHelper::cleanName($fileName, 32); // TODO: Add uniqid for title, so there's no unique conflict
 		$model->originalName = $fileName;
 
 		$model->type = 1; //P3Media::TYPE_FILE;

--- a/migrations/m130827_201909_update_title_length.php
+++ b/migrations/m130827_201909_update_title_length.php
@@ -1,0 +1,134 @@
+<?php
+
+class m130827_201909_update_title_length extends EDbMigration
+{
+	public function safeUp()
+	{
+        if (Yii::app()->db->schema instanceof CMysqlSchema) {
+            $options = 'ENGINE=InnoDB DEFAULT CHARSET=utf8';
+        } else {
+            $options = '';
+        }
+
+        $this->createTable(
+            "p3_media_130827",
+            array(
+                "id" => "int(11) NOT NULL PRIMARY KEY AUTO_INCREMENT",
+                "title" => "varchar(64) NOT NULL",
+                "description" => "text",
+                "type" => "int(11) NOT NULL",
+                "path" => "varchar(255) DEFAULT NULL",
+                "md5" => "varchar(32) DEFAULT NULL",
+                "originalName" => "varchar(128) DEFAULT NULL",
+                "mimeType" => "varchar(128) DEFAULT NULL",
+                "size" => "int(11) DEFAULT NULL",
+                "info" => "text",
+                "nameId" => "varchar(64) DEFAULT NULL",
+                "UNIQUE KEY `p3_media_nameId_unique` (`nameId`)"
+            ),
+            $options
+        );
+
+        $sqlStatement = "SELECT * FROM p3_media";
+        $command = $this->dbConnection->createCommand($sqlStatement);
+        $command->execute();
+
+        $reader = $command->query();
+
+        foreach($reader as $row) {
+            $this->insert(
+                "p3_media_130827",
+                array(
+                    "id"            => $row['id'],
+                    "title"         => $row['title'],
+                    "description"   => $row['description'],
+                    "type"          => $row['type'],
+                    "path"          => $row['path'],
+                    "md5"           => $row['md5'],
+                    "originalName"  => $row['originalName'],
+                    "mimeType"      => $row['mimeType'],
+                    "size"          => $row['size'],
+                    "info"          => $row['info'],
+                    "nameId"        => $row['nameId']
+                )
+            );
+        }
+        
+        if (Yii::app()->db->schema instanceof CMysqlSchema) {
+           $this->execute('SET FOREIGN_KEY_CHECKS = 0;');
+        }
+
+        $this->dropTable('p3_media');
+
+        if (Yii::app()->db->schema instanceof CMysqlSchema) {
+           $this->execute('SET FOREIGN_KEY_CHECKS = 1;');
+        }
+
+        $this->renameTable('p3_media_130827', 'p3_media');
+	}
+
+	public function safeDown()
+	{
+        if (Yii::app()->db->schema instanceof CMysqlSchema) {
+            $options = 'ENGINE=InnoDB DEFAULT CHARSET=utf8';
+        } else {
+            $options = '';
+        }
+
+        $this->createTable(
+            "p3_media_down_130827",
+            array(
+                "id" => "int(11) NOT NULL PRIMARY KEY AUTO_INCREMENT",
+                "title" => "varchar(32) NOT NULL",
+                "description" => "text",
+                "type" => "int(11) NOT NULL",
+                "path" => "varchar(255) DEFAULT NULL",
+                "md5" => "varchar(32) DEFAULT NULL",
+                "originalName" => "varchar(128) DEFAULT NULL",
+                "mimeType" => "varchar(128) DEFAULT NULL",
+                "size" => "int(11) DEFAULT NULL",
+                "info" => "text",
+                "nameId" => "varchar(64) DEFAULT NULL",
+                "UNIQUE KEY `p3_media_nameId_unique` (`nameId`)"
+            ),
+            $options
+        );
+
+        $sqlStatement = "SELECT * FROM p3_media";
+        $command = $this->dbConnection->createCommand($sqlStatement);
+        $command->execute();
+
+        $reader = $command->query();
+
+        foreach($reader as $row) {
+            $this->insert(
+                "p3_media_down_130827",
+                array(
+                    "id"            => $row['id'],
+                    "title"         => $row['title'],
+                    "description"   => $row['description'],
+                    "type"          => $row['type'],
+                    "path"          => $row['path'],
+                    "md5"           => $row['md5'],
+                    "originalName"  => $row['originalName'],
+                    "mimeType"      => $row['mimeType'],
+                    "size"          => $row['size'],
+                    "info"          => $row['info'],
+                    "nameId"        => $row['nameId']
+                )
+            );
+        }
+        
+        if (Yii::app()->db->schema instanceof CMysqlSchema) {
+           $this->execute('SET FOREIGN_KEY_CHECKS = 0;');
+        }
+
+        $this->dropTable('p3_media');
+
+        if (Yii::app()->db->schema instanceof CMysqlSchema) {
+           $this->execute('SET FOREIGN_KEY_CHECKS = 1;');
+        }
+
+        $this->renameTable('p3_media_down_130827', 'p3_media');
+	}
+}

--- a/models/BaseP3Media.php
+++ b/models/BaseP3Media.php
@@ -52,10 +52,10 @@ abstract class BaseP3Media extends CActiveRecord{
 			array('title', 'required'),
 			array('description, type, path, md5, originalName, mimeType, nameId, size, info', 'default', 'setOnEmpty' => true, 'value' => null),
 			array('type, size', 'numerical', 'integerOnly'=>true),
-			array('title, md5', 'length', 'max'=>32),
+			array('md5', 'length', 'max'=>32),
 			array('path', 'length', 'max'=>255),
 			array('originalName, mimeType', 'length', 'max'=>128),
-            array('nameId', 'length', 'max' => 64),
+            array('title, nameId', 'length', 'max' => 64),
 			array('description, info', 'safe'),
 			array('id, title, description, type, path, md5, originalName, mimeType, size, info', 'safe', 'on'=>'search'),
 		);


### PR DESCRIPTION
- update initialization on import
- update validation rules

I created this migration to update the length of the "title" column on the p3_media table. This allows uploading images with longer file names and they will not be cut off after 32 chars.

In the migration I had to deactivate ForeignKey checks when I drop the p3_media table for renaming - since I have a number of constraints to this table. Not sure if you want to include that, but this might still be useful as a starting point.
