### PR TITLE
added action 'ajaxSearch' to 'P3media.P3Media.*' (master)role

### DIFF
--- a/controllers/P3MediaController.php
+++ b/controllers/P3MediaController.php
@@ -22,7 +22,7 @@ public function accessRules()
      return array(
         array(
             'allow',
-            'actions' => array('create', 'admin', 'view', 'update', 'editableSaver', 'delete'),
+            'actions' => array('create', 'admin', 'view', 'update', 'editableSaver', 'delete', 'ajaxSearch'),
             'roles' => array('P3media.P3Media.*'),
         ),
         array(


### PR DESCRIPTION
If you have the (master)role 'P3media.P3Media.*' you should be allowed to use the 'ajaxSearch' action (i.e. for the P3MediaSelect widget)
