### PR TITLE
Change Redirect Status Code

### DIFF
--- a/actions/P3MediaImageAction.php
+++ b/actions/P3MediaImageAction.php
@@ -53,7 +53,7 @@ class P3MediaImageAction extends CAction
             $result = self::processMediaFile($identifier, $preset);
             switch ($result['type']) {
                 case 'public':
-                    header('location: ' . $result['data']);
+                    header('location: ' . $result['data'], true, 301);
                     break;
                 case 'protected':
                     $model = self::findModel($identifier);


### PR DESCRIPTION
Redirect to public URL should be send with Status 301 not 302 to avoid requests to the origin URL.